### PR TITLE
Fix errors in config and optimise configuration for trimming and alignment based on test run

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -4,9 +4,9 @@ process {
 
   withName: 'trimming' {
     clusterOptions = '--job-name=trim'
-    cpus = 16
-    memory = '20 GB'
-    time = '12:00:00'
+    cpus = 3
+    memory = '3 GB'
+    time = '04:00:00'
   }
 
   withName: 'align' {

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,49 +4,49 @@ process {
 
   withName: 'trimming' {
     clusterOptions = '--job-name=trim'
-    cpus = 3
-    memory = '3 GB'
-    time = '04:00:00'
+    cpus = 4
+    memory = '4 GB'
+    time = '08:00:00'
   }
 
   withName: 'align' {
     clusterOptions = '--job-name=align'
     cpus = 16
-    memory = '20 GB'
-    time = '18:00:00'
-  }
-
-  withName: 'align_downsample' {
-    clusterOptions = '--job-name=align_downsample'
-    cpus = 1
-    memory = '12 GB'
-    time = '12:00:00'
+    memory = '16 GB'
+    time = '08:00:00'
   }
 
   withName: 'merge_sort' {
     clusterOptions = '--job-name=merge_sort'
     cpus = 8
-    memory = '20 GB'
-    time = '18:00:00'
+    memory = '16 GB'
+    time = '08:00:00'
   }
 
   withName: 'mark_dup' {
     clusterOptions = '--job-name=mark_dup'
     cpus = 1
-    memory = '20 GB'
-    time = '18:00:00'
+    memory = '24 GB'
+    time = '08:00:00'
   }
 
   withName: 'cram_convert' {
     clusterOptions = '--job-name=cram_convert'
     cpus = 4
-    memory = '20 GB'
-    time = '18:00:00'
+    memory = '2 GB'
+    time = '01:00:00'
   }
 
   withName: 'calc_stats' {
     clusterOptions = '--job-name=calc_stats'
-    cpus = 4
+    cpus = 2
+    memory = '2 GB'
+    time = '01:00:00'
+  }
+  
+  withName: 'align_downsample' {
+    clusterOptions = '--job-name=align_downsample'
+    cpus = 1
     memory = '12 GB'
     time = '12:00:00'
   }
@@ -79,7 +79,7 @@ process {
     time = '12:00:00'
   }
 
-  withName: 'rm_indel' {
+  withName: 'rm_indels' {
     clusterOptions = '--job-name=rm_indel'
     cpus = 4
     memory = '12 GB'

--- a/nextflow_saga.config
+++ b/nextflow_saga.config
@@ -4,49 +4,49 @@ process {
 
   withName: 'trimming' {
     clusterOptions = '--account=nn10082k --job-name=trim'
-    cpus = 3
-    memory = '3 GB'
-    time = '04:00:00'
+    cpus = 4
+    memory = '4 GB'
+    time = '08:00:00'
   }
 
   withName: 'align' {
     clusterOptions = '--account=nn10082k --job-name=align'
     cpus = 16
-    memory = '20 GB'
-    time = '18:00:00'
-  }
-  
-  withName: 'align_downsample' {
-    clusterOptions = '--account=nn10082k --job-name=align_downsample'
-    cpus = 1
-    memory = '12 GB'
-    time = '12:00:00'
+    memory = '16 GB'
+    time = '08:00:00'
   }
 
   withName: 'merge_sort' {
     clusterOptions = '--account=nn10082k --job-name=merge_sort'
     cpus = 8
-    memory = '20 GB'
-    time = '18:00:00'
+    memory = '16 GB'
+    time = '08:00:00'
   }
 
   withName: 'mark_dup' {
     clusterOptions = '--account=nn10082k --job-name=mark_dup'
     cpus = 1
-    memory = '20 GB'
-    time = '18:00:00'
+    memory = '24 GB'
+    time = '08:00:00'
   }
 
   withName: 'cram_convert' {
     clusterOptions = '--account=nn10082k --job-name=cram_convert'
     cpus = 4
-    memory = '20 GB'
-    time = '18:00:00'
+    memory = '2 GB'
+    time = '01:00:00'
   }
 
   withName: 'calc_stats' {
     clusterOptions = '--account=nn10082k --job-name=calc_stats'
-    cpus = 4
+    cpus = 2
+    memory = '2 GB'
+    time = '01:00:00'
+  }
+  
+  withName: 'align_downsample' {
+    clusterOptions = '--account=nn10082k --job-name=align_downsample'
+    cpus = 1
     memory = '12 GB'
     time = '12:00:00'
   }
@@ -79,7 +79,7 @@ process {
     time = '12:00:00'
   }
 
-  withName: 'rm_indel' {
+  withName: 'rm_indels' {
     clusterOptions = '--account=nn10082k --job-name=rm_indel'
     cpus = 4
     memory = '12 GB'

--- a/nextflow_saga.config
+++ b/nextflow_saga.config
@@ -4,9 +4,9 @@ process {
 
   withName: 'trimming' {
     clusterOptions = '--account=nn10082k --job-name=trim'
-    cpus = 16
-    memory = '20 GB'
-    time = '12:00:00'
+    cpus = 3
+    memory = '3 GB'
+    time = '04:00:00'
   }
 
   withName: 'align' {


### PR DESCRIPTION
Fixed a typo here that would throw an error at the `rm_indels` process, so this branch should merge to `correct-config`. Optimisations are a bonus, process described briefly below.

The trim-and-align processes all parallelise across individuals, not genome windows - so testing their memory and CPU utilisation was relatively easy on a small test dataset because it should scale predictably with file size for an individual (which we have a reasonable idea of). Testing the optimal config for the genotyping and filtering steps will necessarily involve testing a very large dataset and extrapolating from there. That's a bit more complicated to do.