### PR TITLE
Ensure only end-point VCFs are placed in published directories, clarify naming

### DIFF
--- a/2_call_variants.nf
+++ b/2_call_variants.nf
@@ -89,8 +89,6 @@ process vcf_concat {
 // normalise vcf
 process vcf_normalise {
 
-    publishDir 'vcf', saveAs: { filename -> "$filename" }
-
     input:
     tuple \
     val(key),

--- a/3_filter_variants.nf
+++ b/3_filter_variants.nf
@@ -17,7 +17,7 @@ params.min_geno_depth=5
 params.max_geno_depth=30
 params.keep="./path/to/file"
 
-// Step 1 - rm_indels -  remove spanning deletions,indels and normalise
+// Step 1 - rm_indels -  re-normalise after removing spanning deletions, indels
 process rm_indels {
 
   input:
@@ -62,8 +62,10 @@ process vcf_filter {
     # for pop structure
     vcftools --gzvcf $rm_indel_vcf  --remove-indels --remove-filtered-all \
     --keep ${params.keep} \
-    --min-alleles 2 --max-alleles 2 \
-    --max-missing ${params.miss} --minQ ${params.q_site1} \
+    --min-alleles 2 \
+    --max-alleles 2 \
+    --max-missing ${params.miss} \
+    --minQ ${params.q_site1} \
     --min-meanDP ${params.min_depth} --max-meanDP ${params.max_depth} \
     --minDP ${params.min_geno_depth} --maxDP ${params.max_geno_depth} \
     --recode --recode-INFO-all --stdout | \

--- a/3_filter_variants.nf
+++ b/3_filter_variants.nf
@@ -25,15 +25,15 @@ process rm_indels {
 
   output:
   tuple \
-    file ("${anno_vcf.simpleName}_norm.vcf.gz"), \
-    file ("${anno_vcf.simpleName}_norm.vcf.gz.csi") 
+    file ("${anno_vcf.simpleName}.vcf.gz"), \
+    file ("${anno_vcf.simpleName}.vcf.gz.csi") 
 
-  //path 'norm.vcf.gz*' into norm_vcfs
+  //path '.vcf.gz*' into rm_indel_vcfs
 
   """
-  bcftools view --threads ${task.cpus} -V indels -e 'ALT="*" | N_ALT>1' $anno_vcf | bcftools norm --threads ${task.cpus} -D -O z -o ${anno_vcf.simpleName}_norm.vcf.gz
+  bcftools view --threads ${task.cpus} -V indels -e 'ALT="*" | N_ALT>1' $anno_vcf | bcftools norm --threads ${task.cpus} -D -O z -o ${anno_vcf.simpleName}.vcf.gz
 
-  bcftools index --threads ${task.cpus} ${anno_vcf.simpleName}_norm.vcf.gz
+  bcftools index --threads ${task.cpus} ${anno_vcf.simpleName}.vcf.gz
   """
 
 }
@@ -45,14 +45,14 @@ process vcf_filter {
   publishDir 'vcf_filtered', saveAs: { filename -> "$filename" }, mode: 'copy'
 
   input:
-  tuple file(norm_vcf), file(norm_vcf_index) 
+  tuple file(rm_indel_vcf), file(rm_indel_vcf_index) 
 
   output:
   tuple \
-    file ("${norm_vcf.simpleName}_filtered_ps.vcf.gz"), \
-    file ("${norm_vcf.simpleName}_filtered_ps.vcf.gz.csi"), \
-    file ("${norm_vcf.simpleName}_filtered_gs.vcf.gz"), \
-    file ("${norm_vcf.simpleName}_filtered_gs.vcf.gz.csi") 
+    file ("${rm_indel_vcf.simpleName}_filtered_ps.vcf.gz"), \
+    file ("${rm_indel_vcf.simpleName}_filtered_ps.vcf.gz.csi"), \
+    file ("${rm_indel_vcf.simpleName}_filtered_gs.vcf.gz"), \
+    file ("${rm_indel_vcf.simpleName}_filtered_gs.vcf.gz.csi") 
 
   """
   if [[ -f ${params.keep} ]]; then
@@ -60,53 +60,53 @@ process vcf_filter {
     echo "File of individuals to filter provided - adding --keep option."
 
     # for pop structure
-    vcftools --gzvcf $norm_vcf  --remove-indels --remove-filtered-all \
+    vcftools --gzvcf $rm_indel_vcf  --remove-indels --remove-filtered-all \
     --keep ${params.keep} \
     --min-alleles 2 --max-alleles 2 \
     --max-missing ${params.miss} --minQ ${params.q_site1} \
     --min-meanDP ${params.min_depth} --max-meanDP ${params.max_depth} \
     --minDP ${params.min_geno_depth} --maxDP ${params.max_geno_depth} \
     --recode --recode-INFO-all --stdout | \
-    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${norm_vcf.simpleName}_filtered_ps.vcf.gz
+    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${rm_indel_vcf.simpleName}_filtered_ps.vcf.gz
 
-    bcftools index --threads ${task.cpus} ${norm_vcf.simpleName}_filtered_ps.vcf.gz
+    bcftools index --threads ${task.cpus} ${rm_indel_vcf.simpleName}_filtered_ps.vcf.gz
 
     # for genome scans
-    vcftools --gzvcf $norm_vcf --remove-indels --remove-filtered-all \
+    vcftools --gzvcf $rm_indel_vcf --remove-indels --remove-filtered-all \
     --keep ${params.keep} \
     --max-alleles 2 \
     --minQ ${params.q_site2} \
     --min-meanDP ${params.min_depth} --max-meanDP ${params.max_depth} \
     --minDP ${params.min_geno_depth} --maxDP ${params.max_geno_depth} \
     --recode --recode-INFO-all --stdout | \
-    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${norm_vcf.simpleName}_filtered_gs.vcf.gz
+    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${rm_indel_vcf.simpleName}_filtered_gs.vcf.gz
     
-    bcftools index --threads ${task.cpus} ${norm_vcf.simpleName}_filtered_gs.vcf.gz
+    bcftools index --threads ${task.cpus} ${rm_indel_vcf.simpleName}_filtered_gs.vcf.gz
 
   else
 
     echo "Not filtering for specific individuals"
     # for pop structure
-    vcftools --gzvcf $norm_vcf  --remove-indels --remove-filtered-all \
+    vcftools --gzvcf $rm_indel_vcf  --remove-indels --remove-filtered-all \
     --min-alleles 2 --max-alleles 2 \
     --max-missing ${params.miss} --minQ ${params.q_site1} \
     --min-meanDP ${params.min_depth} --max-meanDP ${params.max_depth} \
     --minDP ${params.min_geno_depth} --maxDP ${params.max_geno_depth} \
     --recode --recode-INFO-all --stdout | \
-    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${norm_vcf.simpleName}_filtered_ps.vcf.gz
+    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${rm_indel_vcf.simpleName}_filtered_ps.vcf.gz
 
-    bcftools index --threads ${task.cpus} ${norm_vcf.simpleName}_filtered_ps.vcf.gz
+    bcftools index --threads ${task.cpus} ${rm_indel_vcf.simpleName}_filtered_ps.vcf.gz
 
     # for genome scans
-      vcftools --gzvcf $norm_vcf --remove-indels --remove-filtered-all \
+      vcftools --gzvcf $rm_indel_vcf --remove-indels --remove-filtered-all \
     --max-alleles 2 \
     --minQ ${params.q_site2} \
     --min-meanDP ${params.min_depth} --max-meanDP ${params.max_depth} \
     --minDP ${params.min_geno_depth} --maxDP ${params.max_geno_depth} \
     --recode --recode-INFO-all --stdout | \
-    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${norm_vcf.simpleName}_filtered_gs.vcf.gz
+    bcftools view --threads ${task.cpus} -e 'N_ALT>1' -O z -o ${rm_indel_vcf.simpleName}_filtered_gs.vcf.gz
     
-    bcftools index --threads ${task.cpus} ${norm_vcf.simpleName}_filtered_gs.vcf.gz
+    bcftools index --threads ${task.cpus} ${rm_indel_vcf.simpleName}_filtered_gs.vcf.gz
 
   fi
   """


### PR DESCRIPTION
An intermediate VCF with the suffix `norm` was previously published into the `vcf` directory after `2_call_variants.nf`. This caused both confusion and down-stream errors when two sets of VCF files were passed to `3_filter_variants.nf`.

Resolved by ensuring only final VCF files are published from each script. As an added bonus, clarify their naming throughout.