### PR TITLE
Hotfix (2.0.2)

### DIFF
--- a/pipeline/nextflow/trim_align_reads.nf
+++ b/pipeline/nextflow/trim_align_reads.nf
@@ -253,8 +253,8 @@ process get_final_alignment_stats {
 
     container "quay.io/biocontainers/samtools:1.17--hd87286a_1"
     cpus 1
-    memory { 128.MB * Math.ceil(cram.size() / 1024 ** 3) * task.attempt }
-    time { 6.m * Math.ceil(cram.size() / 1024 ** 3) * task.attempt }
+    memory { 1.MB * Math.max(1024, 128 * Math.ceil(cram.size() / 1024 ** 3)) * task.attempt }
+    time { 1.m * Math.max(20, 6 * Math.ceil(cram.size() / 1024 ** 3)) * task.attempt }
 
     errorStrategy "retry"
     maxRetries 3


### PR DESCRIPTION
This hotfix includes minimum dynamic resource allocations in `trim_align_reads.nf`, to circumvent resource deficiency problems with small input read files.

For small raw read files the dynamic resource allocations in `trim_align_reads.nf` without a minimum value become insufficient even after multiple retries, causing the pipeline to fail. This occurs at some point below 2 GB for each of R1 and R2 (which was the minimum tested originally in #17, although it is unclear at exactly what size the dynamic allocation becomes too small).