### PR TITLE
Hotfix (2.1.2)

### DIFF
--- a/pipeline/nextflow/qc_utils.nf
+++ b/pipeline/nextflow/qc_utils.nf
@@ -73,8 +73,8 @@ process downsample_reads {
 
     script:
     """
-    seqkit ID --two-pass -n ${params.read_target} -o ${R1.simpleName}_downsampled.fastq.gz ${R1}
-    seqkit ID --two-pass -n ${params.read_target} -o ${R2.simpleName}_downsampled.fastq.gz ${R2}
+    seqkit sample --two-pass -n ${params.read_target} -o ${R1.simpleName}_downsampled.fastq.gz ${R1}
+    seqkit sample --two-pass -n ${params.read_target} -o ${R2.simpleName}_downsampled.fastq.gz ${R2}
     mv ${R1.simpleName}_downsampled.fastq.gz ${R1.simpleName}.fastq.gz
     mv ${R2.simpleName}_downsampled.fastq.gz ${R2.simpleName}.fastq.gz
     """

--- a/pipeline/nextflow/qc_utils.nf
+++ b/pipeline/nextflow/qc_utils.nf
@@ -59,7 +59,7 @@ process downsample_reads {
     
     container "quay.io/biocontainers/seqkit:2.10.0--h9ee0642_0"
     cpus 2
-    memory { 256.MB * Math.ceil((R1.size() + R2.size()) / 1024 ** 3) * task.attempt }
+    memory { 1.GB * Math.ceil((R1.size() + R2.size()) / 1024 ** 3) * task.attempt }
     time { 3.m * Math.ceil((R1.size() + R2.size()) / 1024 ** 3) * task.attempt }
 
     errorStrategy "retry"


### PR DESCRIPTION
Resolves #25 and increases dynamic memory allocation to err on the side of fewer retries for larger FASTQ files.