### PR TITLE
Update read_target documentation in main script

### DIFF
--- a/genotyping_pipeline.slurm.sh
+++ b/genotyping_pipeline.slurm.sh
@@ -34,7 +34,7 @@
     phase_variants=yes
 
     # SET OPTIONS FOR TRIM AND ALIGN STEP
-    # Note: The read_target only applies if downsample_reads=yes
+    # Note: The read_target is applied separately to R1 and R2 (if downsample_reads=yes)
     # Note: The default flag, 0x400, is for optical and PCR duplicates
     deduplicate_reads=no
     downsample_reads=no


### PR DESCRIPTION
It was not previously clear that the `read_target` user input applied separately to *each* of R1 and R2, so that e.g. `read_target=1000000` would yield 2M total reads for the sample. This is now clarified.