### PR TITLE
Hotfix 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ flowchart TB
    v14(["Concatenate chromosome VCF (bcftools concat, bcftools index)"])
    v16(["Normalise VCF, remove spanning indels (bcftools norm, bcftools view)"])
    v17(["Reheader VCF (bcftools reheader)"])
+   v18(["Sort VCF samples (bcftools query, bcftools view)"])
    v19(["Get VCF stats (bcftools stats)"])
    v21(["Collect genome-wide stats (bcftools plot-vcfstats)"])
    v23(["Optional: Concatenate genome-wide VCF (bcftools concat, bcftools index)"])
@@ -173,14 +174,15 @@ flowchart TB
    v4 --> v16
    v14 --> v16
    v16 --> v17
-   v17 --> v19
+   v17 --> v18
+   v18 --> v19
    v19 --> v21
-   v17 --> v23
+   v18 --> v23
    v22 --> v23
    v21 --> v26
    v23 --> v24
    v23 --> v25
-   v14 --> v27
+   v18 --> v27
    subgraph "Outputs"
    v24["unfiltered_variants.vcf.gz"]
    v25["unfiltered_variants.vcf.gz.csi"]

--- a/genotyping_pipeline.slurm.sh
+++ b/genotyping_pipeline.slurm.sh
@@ -154,6 +154,8 @@ if [ $filter_variants = "yes" ]; then
         -with-report $filter_variants_output_dir/workflow_report.html \
         -profile $nextflow_profile \
         --vcf_dir $call_variants_output_dir/chroms \
+        --ref_index $ref_index \
+        --ref_scaffold_name $ref_scaffold_name \
         --filtering_label $filtering_label \
         --min_alleles $filtering_min_alleles \
         --max_alleles $filtering_max_alleles \

--- a/pipeline/nextflow/call_variants.nf
+++ b/pipeline/nextflow/call_variants.nf
@@ -137,10 +137,10 @@ process genotype_windows {
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 4
     memory { 2.GB * task.attempt }
-    time 6.h
+    time { 4.h * task.attempt }
 
-    errorStrategy 'retry'
-    maxRetries 5
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     path(crams)
@@ -170,8 +170,11 @@ process concatenate_windows {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 2
-    memory 1.GB
-    time 2.h
+    memory { 2.GB * task.attempt }
+    time { 2.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     tuple val(key), path(window_vcfs_in_key)
@@ -192,8 +195,11 @@ process normalise_vcf {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 2
-    memory 1.GB
-    time 6.h
+    memory { 2.GB * task.attempt }
+    time { 4.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     tuple val(key), path('input.vcf.gz'), path('input.vcf.gz.csi')
@@ -221,8 +227,11 @@ process reheader_vcf {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 2
-    memory 1.GB
-    time 1.h
+    memory { 2.GB * task.attempt }
+    time { 2.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     tuple val(key), path('input.vcf.gz'), path('input.vcf.gz.csi')
@@ -245,8 +254,11 @@ process sort_vcf_samples {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 2
-    memory 1.GB
-    time 2.h
+    memory { 2.GB * task.attempt }
+    time { 2.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     tuple val(key), path('input.vcf.gz'), path('input.vcf.gz.csi')
@@ -267,8 +279,11 @@ process summarise_vcf {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 2
-    memory 1.GB
-    time 2.h
+    memory { 2.GB * task.attempt }
+    time { 2.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     tuple path(vcf), path(csi)
@@ -290,8 +305,11 @@ process concatenate_vchks {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 1
-    memory 1.GB
-    time 1.h
+    memory { 2.GB * task.attempt }
+    time { 2.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     path(collected_vchks), stageAs: "staged_vchks/*"
@@ -318,8 +336,11 @@ process concatenate_vcfs {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 4
-    memory 4.GB
-    time 4.h
+    memory { 4.GB * task.attempt }
+    time { 4.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
     
     input:
     path(collected_vcfs), stageAs: "staged_vcfs/*"

--- a/pipeline/nextflow/filter_variants.nf
+++ b/pipeline/nextflow/filter_variants.nf
@@ -45,8 +45,11 @@ process filter_vcf {
   // Container: https://wave.seqera.io/view/builds/bd-39fc8ab24f49f2d6_1
   container "community.wave.seqera.io/library/bcftools_vcftools:39fc8ab24f49f2d6"
   cpus 2
-  memory 1.GB
-  time 2.h
+  memory { 2.GB * task.attempt }
+  time { 2.h * task.attempt }
+  
+  errorStrategy "retry"
+  maxRetries 3
   
   input:
   tuple val(key), path('input.vcf.gz'), path('input.vcf.gz.csi') 

--- a/pipeline/nextflow/filter_variants.nf
+++ b/pipeline/nextflow/filter_variants.nf
@@ -30,7 +30,7 @@ workflow{
 
   // Concatenate and output chromosome-level VCFs and VCHKs
   concatenate_vchks(filtered_chromosome_vchks.collect(), "variants_${params.filtering_label}")
-  concatenate_vcfs(filtered_chromosome_vcfs.flatten().collect(), "variants_${params.filtering_label}")
+  concatenate_vcfs(filtered_chromosome_vcfs.flatten().collect(), params.ref_index, params.ref_scaffold_name, "variants_${params.filtering_label}")
 
   // Separately:
   save_filters_to_file()

--- a/pipeline/nextflow/phase_variants.nf
+++ b/pipeline/nextflow/phase_variants.nf
@@ -33,8 +33,8 @@ process phase_common_variants {
     
     container "quay.io/biocontainers/shapeit5:5.1.1--hb60d31d_0"
     cpus 2
-    memory { 1.GB + (1.GB * Math.log(Math.ceil(unphased_vcf.size() / 1024 ** 3))) * task.attempt }
-    time { 1.m * Math.ceil(unphased_vcf.size() / 1024 ** 3) * task.attempt }
+    memory { 2.GB + (1.GB * Math.log(Math.ceil(unphased_vcf.size() / 1024 ** 3))) * task.attempt }
+    time { 2.m * Math.ceil(unphased_vcf.size() / 1024 ** 3) * task.attempt }
 
     // SHAPEIT5 exits with an error if there are no variants in the window. If so, ignore the window.
     errorStrategy { task.exitStatus in 137..140 ? "retry" : "ignore" }
@@ -73,8 +73,8 @@ process ligate_phased {
 
     container "quay.io/biocontainers/shapeit5:5.1.1--hb60d31d_0"
     cpus 1
-    memory { 1.GB * task.attempt }
-    time { 30.m * task.attempt }
+    memory { 2.GB * task.attempt }
+    time { 2.h * task.attempt }
 
     errorStrategy "retry"
     maxRetries 3
@@ -99,8 +99,11 @@ process convert_bcf_to_vcf {
 
     container "quay.io/biocontainers/bcftools:1.17--h3cc50cf_1"
     cpus 1
-    memory { 1.GB * task.attempt }
-    time { 30.m * task.attempt }
+    memory { 2.GB * task.attempt }
+    time { 2.h * task.attempt }
+
+    errorStrategy "retry"
+    maxRetries 3
 
     input:
     tuple val(key), path(bcf), path(csi)


### PR DESCRIPTION
Ensures output VCFs are sorted, and allows more spacious dynamic resource allocations for large and/or more unpredictably resource-intensive datasets. With time and experience, the current dynamic resource allocations can be adjusted if they are too high - or tuned better to input file sizes, sample counts, and site counts, etc.

Resolves #28, resolves #29, and resolves #30.

**Note:** #30 could have been solved more efficiently by sorting the input CRAMs, but the present solution works for a hotfix.